### PR TITLE
Fix files

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,8 @@
     "process"
   ],
   "files": [
-    "examples/",
-    "README.md",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "license": "MIT"
 }


### PR DESCRIPTION
I was using this package and noticed there are TypeScript definitions for it. The only thing is, they aren't being shipped to npm and thus are not ending up in `node_modules` which means TypeScript can't find them.

I removed `README.md` because that one is shipped by default.

I also removed `examples/` because those are not something you want to ship to your end users. Nobody will look in `node_modules` to find examples running a package.

Feel free to ignore the PR, but thought these are some small beneficial changes :).